### PR TITLE
Use shell logger param to get the logging engine

### DIFF
--- a/src/Shell/QueuesadillaShell.php
+++ b/src/Shell/QueuesadillaShell.php
@@ -16,7 +16,7 @@ class QueuesadillaShell extends Shell
      */
     public function main()
     {
-        $logger = Log::engine($this->getLoggerName('stdout'));
+        $logger = Log::engine($this->params['logger']);
         $engine = $this->getEngine($logger);
         $worker = $this->getWorker($engine, $logger);
         $worker->work();
@@ -55,21 +55,6 @@ class QueuesadillaShell extends Shell
         return new $WorkerClass($engine, $logger, [
             'queue' => $engine->config('queue'),
         ]);
-    }
-
-    /**
-     * Retrieves a name of a logger engine to use
-     *
-     * @param array $config Default logger name
-     * @return string
-     */
-    public function getLoggerName($loggerName = null)
-    {
-        if (empty($loggerName)) {
-            $loggerName = $this->params['logger'];
-        }
-
-        return $loggerName;
     }
 
     /**

--- a/tests/TestCase/Shell/QueuesadillaShellTest.php
+++ b/tests/TestCase/Shell/QueuesadillaShellTest.php
@@ -78,21 +78,6 @@ class QueuesadillaShellTest extends TestCase
     }
 
     /**
-     * Test that the logger name is a string
-     *
-     * @return void
-     */
-    public function testGetLoggerName()
-    {
-        $loggerName = $this->shell->getLoggerName('name');
-        $this->assertEquals('name', $loggerName);
-
-        $this->shell->params['logger'] = 'stdout';
-        $loggerName = $this->shell->getLoggerName();
-        $this->assertEquals('stdout', $loggerName);
-    }
-
-    /**
      * Test that the option parser is shaped right.
      *
      * @return void


### PR DESCRIPTION
As the default value of --logger is `'stdout'`, we can use it directly in the `main()` method when we get the logging engine.
Removed the now obsolete `getLoggerName()` method and the corresponding test.