### PR TITLE
Add migration to fix no default value errors on the locked column

### DIFF
--- a/config/Migrations/20170123000743_AddDefaultValueForLocked.php
+++ b/config/Migrations/20170123000743_AddDefaultValueForLocked.php
@@ -1,0 +1,16 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddDefaultValueForLocked extends AbstractMigration
+{
+
+    public function change()
+    {
+        $table = $this->table('jobs');
+        $table->changeColumn('locked', 'integer', [
+            'default' => 0
+        ]);
+        $table->update();
+    }
+}
+


### PR DESCRIPTION
This fixes an `PDOException: SQLSTATE[HY000]: General error: 1364 Field 'locked' doesn't have a default value` error occurring on MySql 5.7