### PR TITLE
WIP: Attach the Worker events to the CakePHP Event System

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,6 @@ matrix:
     - php: hhvm
       env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
-    - php: 5.5
-      env: DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-
-    - php: 5.6
-      env: DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-
-    - php: 7.0
-      env: DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,15 @@ matrix:
     - php: hhvm
       env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
+    - php: 5.5
+      env: DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+
+    - php: 5.6
+      env: DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+
+    - php: 7.0
+      env: DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
       env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
 before_script:
-  - pecl install sqlite3
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
       env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
 before_script:
+  - pecl install sqlite3
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "josegonzalez/queuesadilla": "0.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "<6.0",
         "cakephp/cakephp-codesniffer": "dev-master",
         "satooshi/php-coveralls": "dev-master"
     },

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -59,3 +59,29 @@ Need to queue something up?
 You can also add the ``Josegonzalez\CakeQueuesadilla\Traits\QueueTrait`` to any class in order to have a protected ``push`` method added to the class so that you can do ``$this->push()``.
 
 See `here <https://github.com/josegonzalez/php-queuesadilla/blob/master/docs/defining-jobs.md>`_ for more information on defining jobs.
+
+Need to react to Queuesadilla events inside your CakePHP application?
+
+All worker and queue events are propagated to the CakePHP event system.
+To hook into them, do something like this:
+
+.. code:: php
+
+    // Worker events
+    <?php
+    use Cake\Event\EventManager;
+
+    EventManager::instance()->on('Queue.Worker.job.success', function ($event, $worker) {
+        // Access the job data
+         $job = $worker->data['job']
+    });
+
+    // Queue event
+    <?php
+    use Cake\Event\EventManager;
+
+    EventManager::instance()->on('Queue.Queue.afterEnqueue', function ($event, $queue) {
+        // Access the queue item and the success state
+        $item = $queue->data['item'];
+        $success = $queue->data['success'];
+    });

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -288,7 +288,7 @@ class Queue
         $queue = static::queue($config);
 
         $queue->attachListener('Queue.afterEnqueue', function ($event) {
-            $event = new Event('Queue.Queue.afterEnqueue', $this, [
+            $event = new Event('Queue.Queue.afterEnqueue', null, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -3,6 +3,8 @@ namespace Josegonzalez\CakeQueuesadilla\Queue;
 
 use Cake\Core\ObjectRegistry;
 use Cake\Core\StaticConfigTrait;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
 use Josegonzalez\CakeQueuesadilla\Queue\QueueEngineRegistry;
@@ -284,6 +286,13 @@ class Queue
     {
         $config = Hash::get($options, 'config', 'default');
         $queue = static::queue($config);
+
+        $queue->attachListener('Queue.afterEnqueue', function ($event) {
+            $event = new Event('Queue.Queue.afterEnqueue', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
 
         return $queue->push($callable, $args, $options);
     }

--- a/src/Shell/QueuesadillaShell.php
+++ b/src/Shell/QueuesadillaShell.php
@@ -2,6 +2,8 @@
 namespace Josegonzalez\CakeQueuesadilla\Shell;
 
 use Cake\Console\Shell;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Josegonzalez\CakeQueuesadilla\Queue\Queue;
@@ -49,13 +51,17 @@ class QueuesadillaShell extends Shell
      */
     public function getWorker($engine, $logger)
     {
-        $worker = $this->params['worker'];
-        $WorkerClass = "josegonzalez\\Queuesadilla\\Worker\\" . $worker . "Worker";
+        $workerName = $this->params['worker'];
+        $workerClass = "josegonzalez\\Queuesadilla\\Worker\\" . $workerName . "Worker";
 
-        return new $WorkerClass($engine, $logger, [
+        $worker = new $workerClass($engine, $logger, [
             'queue' => $engine->config('queue'),
             'maxRuntime' => $engine->config('maxRuntime')
         ]);
+
+        $this->__attachEvents($worker);
+
+        return $worker;
     }
 
     /**
@@ -91,5 +97,69 @@ class QueuesadillaShell extends Shell
         ])->description(__('Runs a Queuesadilla worker.'));
 
         return $parser;
+    }
+
+    /**
+     * Attach the league/event events to the CakePHP event system
+     *
+     * @param \josegonzalez\Queuesadilla\Worker\Base $worker worker instance
+     * @return void
+     */
+    private function __attachEvents($worker)
+    {
+        $worker->attachListener('Worker.connectionFailed', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.connectionFailed', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
+        $worker->attachListener('Worker.maxIterations', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.maxIterations', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
+        $worker->attachListener('Worker.maxRuntime', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.maxRuntime', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
+        $worker->attachListener('Worker.job.seen', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.job.seen', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
+        $worker->attachListener('Worker.job.empty', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.job.empty', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
+        $worker->attachListener('Worker.job.invalid', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.job.invalid', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
+        $worker->attachListener('Worker.job.exception', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.job.exception', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
+        $worker->attachListener('Worker.job.success', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.job.success', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
+        $worker->attachListener('Worker.job.failure', function ($event) {
+            $event = new Event('CakeQueuesadilla.Worker.job.failure', $this, [
+                'workerEvent' => $event
+            ]);
+            EventManager::instance()->dispatch($event);
+        });
     }
 }

--- a/src/Shell/QueuesadillaShell.php
+++ b/src/Shell/QueuesadillaShell.php
@@ -107,59 +107,25 @@ class QueuesadillaShell extends Shell
      */
     private function attachEvents($worker)
     {
-        $worker->attachListener('Worker.connectionFailed', function ($event) {
-            $event = new Event('Queue.Worker.connectionFailed', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
-        $worker->attachListener('Worker.maxIterations', function ($event) {
-            $event = new Event('Queue.Worker.maxIterations', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
-        $worker->attachListener('Worker.maxRuntime', function ($event) {
-            $event = new Event('Queue.Worker.maxRuntime', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
-        $worker->attachListener('Worker.job.seen', function ($event) {
-            $event = new Event('Queue.Worker.job.seen', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
-        $worker->attachListener('Worker.job.empty', function ($event) {
-            $event = new Event('Queue.Worker.job.empty', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
-        $worker->attachListener('Worker.job.invalid', function ($event) {
-            $event = new Event('Queue.Worker.job.invalid', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
-        $worker->attachListener('Worker.job.exception', function ($event) {
-            $event = new Event('Queue.Worker.job.exception', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
-        $worker->attachListener('Worker.job.success', function ($event) {
-            $event = new Event('Queue.Worker.job.success', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
-        $worker->attachListener('Worker.job.failure', function ($event) {
-            $event = new Event('Queue.Worker.job.failure', $this, [
-                'workerEvent' => $event
-            ]);
-            EventManager::instance()->dispatch($event);
-        });
+        $eventMap = [
+            'Worker.connectionFailed' => 'Queue.Worker.connectionFailed',
+            'Worker.maxIterations' => 'Queue.Worker.maxIterations',
+            'Worker.maxRuntime' => 'Queue.Worker.maxRuntime',
+            'Worker.job.seen' => 'Queue.Worker.job.seen',
+            'Worker.job.empty' => 'Queue.Worker.job.empty',
+            'Worker.job.invalid' => 'Queue.Worker.job.invalid',
+            'Worker.job.exception' => 'Queue.Worker.job.exception',
+            'Worker.job.success' => 'Queue.Worker.job.success',
+            'Worker.job.failure' => 'Queue.Worker.job.failure'
+        ];
+
+        foreach ($eventMap as $queueEvent => $cakeEvent) {
+            $worker->attachListener($queueEvent, function ($event) use ($cakeEvent) {
+                $event = new Event($cakeEvent, $this, [
+                    'workerEvent' => $event
+                ]);
+                EventManager::instance()->dispatch($event);
+            });
+        }
     }
 }

--- a/src/Shell/QueuesadillaShell.php
+++ b/src/Shell/QueuesadillaShell.php
@@ -59,7 +59,7 @@ class QueuesadillaShell extends Shell
             'maxRuntime' => $engine->config('maxRuntime')
         ]);
 
-        $this->__attachEvents($worker);
+        $this->attachEvents($worker);
 
         return $worker;
     }
@@ -105,58 +105,58 @@ class QueuesadillaShell extends Shell
      * @param \josegonzalez\Queuesadilla\Worker\Base $worker worker instance
      * @return void
      */
-    private function __attachEvents($worker)
+    private function attachEvents($worker)
     {
         $worker->attachListener('Worker.connectionFailed', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.connectionFailed', $this, [
+            $event = new Event('Queue.Worker.connectionFailed', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);
         });
         $worker->attachListener('Worker.maxIterations', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.maxIterations', $this, [
+            $event = new Event('Queue.Worker.maxIterations', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);
         });
         $worker->attachListener('Worker.maxRuntime', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.maxRuntime', $this, [
+            $event = new Event('Queue.Worker.maxRuntime', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);
         });
         $worker->attachListener('Worker.job.seen', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.job.seen', $this, [
+            $event = new Event('Queue.Worker.job.seen', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);
         });
         $worker->attachListener('Worker.job.empty', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.job.empty', $this, [
+            $event = new Event('Queue.Worker.job.empty', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);
         });
         $worker->attachListener('Worker.job.invalid', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.job.invalid', $this, [
+            $event = new Event('Queue.Worker.job.invalid', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);
         });
         $worker->attachListener('Worker.job.exception', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.job.exception', $this, [
+            $event = new Event('Queue.Worker.job.exception', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);
         });
         $worker->attachListener('Worker.job.success', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.job.success', $this, [
+            $event = new Event('Queue.Worker.job.success', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);
         });
         $worker->attachListener('Worker.job.failure', function ($event) {
-            $event = new Event('CakeQueuesadilla.Worker.job.failure', $this, [
+            $event = new Event('Queue.Worker.job.failure', $this, [
                 'workerEvent' => $event
             ]);
             EventManager::instance()->dispatch($event);

--- a/src/Shell/QueuesadillaShell.php
+++ b/src/Shell/QueuesadillaShell.php
@@ -56,7 +56,8 @@ class QueuesadillaShell extends Shell
 
         $worker = new $workerClass($engine, $logger, [
             'queue' => $engine->config('queue'),
-            'maxRuntime' => $engine->config('maxRuntime')
+            'maxRuntime' => $engine->config('maxRuntime'),
+            'maxIterations' => $engine->config('maxIterations')
         ]);
 
         $this->attachEvents($worker);
@@ -108,7 +109,7 @@ class QueuesadillaShell extends Shell
     private function attachEvents($worker)
     {
         $eventMap = [
-            'Worker.connectionFailed' => 'Queue.Worker.connectionFailed',
+            'Worker.job.connectionFailed' => 'Queue.Worker.connectionFailed',
             'Worker.maxIterations' => 'Queue.Worker.maxIterations',
             'Worker.maxRuntime' => 'Queue.Worker.maxRuntime',
             'Worker.job.seen' => 'Queue.Worker.job.seen',

--- a/tests/Fixture/JobsFixture.php
+++ b/tests/Fixture/JobsFixture.php
@@ -1,0 +1,47 @@
+<?php
+namespace Josegonzalez\CakeQueuesadilla\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * JobsFixture
+ *
+ */
+class JobsFixture extends TestFixture
+{
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'queue' => ['type' => 'string', 'length' => 32, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'data' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null],
+        'priority' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'expires_at' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'delay_until' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'locked' => ['type' => 'integer', 'length' => 1, 'unsigned' => false, 'null' => false, 'default' => '0', 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'attempts' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        '_indexes' => [
+            'is_locked' => ['type' => 'index', 'columns' => ['queue', 'locked'], 'length' => []],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [];
+}

--- a/tests/Fixture/JobsFixture.php
+++ b/tests/Fixture/JobsFixture.php
@@ -18,13 +18,13 @@ class JobsFixture extends TestFixture
     // @codingStandardsIgnoreStart
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
-        'queue' => ['type' => 'string', 'length' => 32, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'data' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null],
+        'queue' => ['type' => 'string', 'length' => 32, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'data' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
         'priority' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'expires_at' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'delay_until' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'locked' => ['type' => 'integer', 'length' => 1, 'unsigned' => false, 'null' => false, 'default' => '0', 'comment' => '', 'precision' => null, 'autoIncrement' => null],
-        'attempts' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'attempts' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
         '_indexes' => [
             'is_locked' => ['type' => 'index', 'columns' => ['queue', 'locked'], 'length' => []],
         ],

--- a/tests/Fixture/JobsFixture.php
+++ b/tests/Fixture/JobsFixture.php
@@ -30,11 +30,7 @@ class JobsFixture extends TestFixture
         ],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
+        ]
     ];
     // @codingStandardsIgnoreEnd
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -68,7 +68,7 @@ Cake\Core\Plugin::load('Josegonzalez/CakeQueuesadilla', ['path' => ROOT . DS, 'a
 
 // Ensure default test connection is defined
 if (!getenv('db_dsn')) {
-    putenv('db_dsn=sqlite:///:memory:');
+    putenv('db_dsn=mysql://username:password@127.0.0.1/cakephp_test');
 }
 
 Cake\Datasource\ConnectionManager::config('test', [


### PR DESCRIPTION
This is WIP for implementing #7 
I started with the Worker events. Queue is missing, but it's only one event.
Also, tests are missing, but I want to discuss this first.

Now you can do sth. like:

```
use Cake\Event\EventManager;

EventManager::instance()->on('Queue.Worker.job.success', function ($event, $job) {
    debug($job->data['job']);
});
```