### PR TITLE
Implement CakeEngine to use cake datasource. Fix some deprecations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 sudo: false
 
@@ -22,10 +22,10 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 5.5
+    - php: 7.1
       env: PHPCS=1 DEFAULT=0
 
-    - php: 5.5
+    - php: 7.1
       env: COVERALLS=1 DEFAULT=0
 
     - php: hhvm
@@ -50,10 +50,10 @@ before_script:
   - command -v phpenv > /dev/null && phpenv rehash || true
 
 script:
-  - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then vendor/bin/phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -v; fi"
-  - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=vendor --ignore=docs --ignore=tests/bootstrap.php --ignore=config/Migrations . ; fi"
+  - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit --stderr; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=vendor,docs,tests/bootstrap.php,config/Migrations .; fi"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 
 script:
   - sh -c "if [ '$COVERALLS' = '1' ]; then vendor/bin/phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -v; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/satooshi/php-coveralls/bin/php-coveralls -v; fi"
   - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit --stderr; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=vendor,docs,tests/bootstrap.php,config/Migrations .; fi"
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin is a simple wrapper around the Queuesadilla queuing library, providi
 ## Requirements
 
 * CakePHP 3.x
-* PHP 5.4+
+* PHP 5.6+
 * Patience
 
 ## Documentation

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "josegonzalez/queuesadilla": "0.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "^5.7|^6.0",
         "cakephp/cakephp-codesniffer": "dev-master",
         "satooshi/php-coveralls": "dev-master"
     },

--- a/config/Migrations/20170123000743_AddDefaultValueForLocked.php
+++ b/config/Migrations/20170123000743_AddDefaultValueForLocked.php
@@ -3,7 +3,13 @@ use Migrations\AbstractMigration;
 
 class AddDefaultValueForLocked extends AbstractMigration
 {
-
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
     public function change()
     {
         $table = $this->table('jobs');
@@ -13,4 +19,3 @@ class AddDefaultValueForLocked extends AbstractMigration
         $table->update();
     }
 }
-

--- a/config/Migrations/20180109000743_AddCreatedAt.php
+++ b/config/Migrations/20180109000743_AddCreatedAt.php
@@ -1,0 +1,25 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddCreatedAt extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('jobs');
+        $table->addColumn('created_at', 'datetime', [
+            'default' => null,
+            'null' => true,
+        ]);
+        $table->addIndex([
+            'created_at',
+        ]);
+        $table->update();
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,9 @@
             <directory suffix=".php">./vendor</directory>
             <file>./tests/bootstrap.php</file>
         </blacklist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
     </filter>
 
     <!-- Setup a listener for fixtures -->

--- a/src/Engine/CakeEngine.php
+++ b/src/Engine/CakeEngine.php
@@ -39,6 +39,7 @@ class CakeEngine extends PdoEngine
             $this->logger()->error($e->getMessage());
             $this->connection = null;
         }
+
         return (bool)$this->connection;
     }
 }

--- a/src/Engine/CakeEngine.php
+++ b/src/Engine/CakeEngine.php
@@ -5,7 +5,6 @@ use Cake\Core\Exception\Exception;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Hash;
-use PDOException;
 use josegonzalez\Queuesadilla\Engine\PdoEngine;
 
 class CakeEngine extends PdoEngine

--- a/src/Engine/CakeEngine.php
+++ b/src/Engine/CakeEngine.php
@@ -1,0 +1,45 @@
+<?php
+namespace Josegonzalez\CakeQueuesadilla\Engine;
+
+use Cake\Core\Exception\Exception;
+use Cake\Database\Connection;
+use Cake\Datasource\ConnectionManager;
+use Cake\Utility\Hash;
+use PDOException;
+use josegonzalez\Queuesadilla\Engine\PdoEngine;
+
+class CakeEngine extends PdoEngine
+{
+    /**
+     * Base config
+     * @var array
+     */
+    protected $baseConfig = [
+        'delay' => null,
+        'expires_in' => null,
+        'priority' => 0,
+        'queue' => 'default',
+        'attempts' => 0,
+        'attempts_delay' => 600,
+        'table' => 'jobs',
+        'datasource' => 'default'
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function connect()
+    {
+        $config = $this->settings;
+        try {
+            /** @var Connection $connection */
+            $connection = ConnectionManager::get(Hash::get($config, 'datasource'));
+            $connection->connect();
+            $this->connection = $connection->getDriver()->connection();
+        } catch (Exception $e) {
+            $this->logger()->error($e->getMessage());
+            $this->connection = null;
+        }
+        return (bool)$this->connection;
+    }
+}

--- a/src/Shell/QueuesadillaShell.php
+++ b/src/Shell/QueuesadillaShell.php
@@ -88,7 +88,7 @@ class QueuesadillaShell extends Shell
             'default' => 'Sequential',
             'help' => 'Name of worker class',
             'short' => 'w',
-        ])->description(__('Runs a Queuesadilla worker.'));
+        ])->setDescription(__('Runs a Queuesadilla worker.'));
 
         return $parser;
     }

--- a/tests/TestCase/Engine/CakeEngineTest.php
+++ b/tests/TestCase/Engine/CakeEngineTest.php
@@ -1,0 +1,159 @@
+<?php
+namespace Josegonzalez\CakeQueuesadilla\Test\Engine;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use Josegonzalez\CakeQueuesadilla\Queue\Queue;
+
+/**
+ * CakeEngineTest class
+ *
+ */
+class CakeEngineTest extends TestCase
+{
+
+    /**
+     * setup method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        Queue::reset();
+        $this->Logger = $this->getMockBuilder('Cake\Log\Engine\FileLog')
+            ->setMethods(['error'])
+            ->getMock();
+    }
+
+    /**
+     * teardown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        Queue::reset();
+    }
+
+    /**
+     * test config() with valid datasource name
+     *
+     * @return void
+     */
+    public function testValidConfig()
+    {
+        Queue::setConfig('valid', [
+            'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
+            'datasource' => 'test'
+        ]);
+        $engine = Queue::engine('valid');
+        $this->assertInstanceOf('Josegonzalez\CakeQueuesadilla\Engine\CakeEngine', $engine);
+        $this->assertEquals('test', $engine->config('datasource'));
+    }
+
+    /**
+     * test config() with invalid datasource name
+     *
+     * @return void
+     */
+    public function testInvalidDatasourceName()
+    {
+        $this->Logger->expects($this->once())
+            ->method('error')
+            ->with('The datasource configuration "wrong-datasource" was not found.');
+        Queue::setConfig('invalid', [
+            'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
+            'datasource' => 'wrong-datasource'
+        ]);
+        $engine = Queue::engine('invalid');
+        $engine->setLogger($this->Logger);
+        $this->assertInstanceOf('Josegonzalez\CakeQueuesadilla\Engine\CakeEngine', $engine);
+        $this->assertEquals('wrong-datasource', $engine->config('datasource'));
+        $engine->connect();
+    }
+
+    /**
+     * test config() with invalid datasource config (missing datasource class)
+     *
+     * @return void
+     */
+    public function testInvalidConfig()
+    {
+        $this->Logger->expects($this->once())
+            ->method('error')
+            ->with('Datasource class wrong-datasource-class could not be found. ');
+        Queue::setConfig('invalid', [
+            'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
+            'datasource' => 'wrong-datasource-class'
+        ]);
+        ConnectionManager::setConfig('wrong-datasource-class', [
+            'user' => 'invalid-user',
+            'password' => 'invalid-password',
+            'host' => 'localhost'
+        ]);
+        $engine = Queue::engine('invalid');
+        $engine->setLogger($this->Logger);
+        $this->assertFalse($engine->connect());
+    }
+
+    /**
+     * test config() with invalid datasource connection params
+     *
+     * @return void
+     */
+    public function testInvalidConfigParams()
+    {
+        $this->Logger->expects($this->once())
+            ->method('error')
+            ->with($this->matchesRegularExpression('/Connection to database could not be established:/'));
+        Queue::setConfig('invalid', [
+            'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
+            'datasource' => 'wrong-datasource-params'
+        ]);
+        ConnectionManager::setConfig('wrong-datasource-params', [
+            'className' => 'Cake\Database\Connection',
+            'driver' => 'Cake\Database\Driver\Mysql',
+            'user' => 'invalid-user',
+            'password' => 'invalid-password',
+            'host' => 'localhost'
+        ]);
+        $engine = Queue::engine('invalid');
+        $engine->setLogger($this->Logger);
+        $this->assertFalse($engine->connect());
+    }
+
+    /**
+     * test config with noDatasource (default)
+     *
+     * @return void
+     */
+    public function testNoDatasource()
+    {
+        Queue::setConfig('noDatasource', [
+            'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
+        ]);
+        $engine = Queue::engine('noDatasource');
+        $this->assertInstanceOf('Josegonzalez\CakeQueuesadilla\Engine\CakeEngine', $engine);
+        $this->assertEquals('default', $engine->config('datasource'));
+    }
+
+    /**
+     * test connection
+     *
+     * @return void
+     */
+    public function testConnection()
+    {
+        Queue::setConfig('valid', [
+            'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
+            'datasource' => 'test'
+        ]);
+        $engine = Queue::engine('valid');
+        $this->assertInstanceOf('Josegonzalez\CakeQueuesadilla\Engine\CakeEngine', $engine);
+        $this->assertEquals('test', $engine->config('datasource'));
+        $this->assertTrue($engine->connect());
+        $this->assertEquals(ConnectionManager::get('test')->getDriver()->connection(), $engine->connection());
+    }
+}

--- a/tests/TestCase/Queue/QueueTest.php
+++ b/tests/TestCase/Queue/QueueTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cake\Test\TestCase\Log;
+namespace Josegonzalez\CakeQueuesadilla\Test\Queue;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -47,7 +47,7 @@ class QueueTest extends TestCase
      */
     public function testImportingQueueEngineFailure()
     {
-        Queue::config('fail', []);
+        Queue::setConfig('fail', []);
         Queue::engine('fail');
     }
 
@@ -58,8 +58,8 @@ class QueueTest extends TestCase
      */
     public function testValidKeyName()
     {
-        Log::config('stdout', ['engine' => 'File']);
-        Queue::config('valid', [
+        Log::setConfig('stdout', ['engine' => 'File']);
+        Queue::setConfig('valid', [
             'url' => 'mysql://username:password@localhost:80/database'
         ]);
         $engine = Queue::engine('valid');
@@ -74,7 +74,7 @@ class QueueTest extends TestCase
      */
     public function testNotImplementingInterface()
     {
-        Queue::config('fail', ['engine' => '\stdClass']);
+        Queue::setConfig('fail', ['engine' => '\stdClass']);
         Queue::engine('fail');
     }
 
@@ -85,7 +85,7 @@ class QueueTest extends TestCase
      */
     public function testDrop()
     {
-        Queue::config('default', [
+        Queue::setConfig('default', [
             'url' => 'mysql://username:password@localhost:80/database'
         ]);
         $result = Queue::configured();
@@ -105,7 +105,7 @@ class QueueTest extends TestCase
      */
     public function testConfigErrorOnReconfigure()
     {
-        Queue::config('tests', ['url' => 'mysql://username:password@localhost:80/database']);
-        Queue::config('tests', ['url' => 'null://']);
+        Queue::setConfig('tests', ['url' => 'mysql://username:password@localhost:80/database']);
+        Queue::setConfig('tests', ['url' => 'null://']);
     }
 }

--- a/tests/TestCase/Shell/QueuesadillaShellTest.php
+++ b/tests/TestCase/Shell/QueuesadillaShellTest.php
@@ -49,8 +49,8 @@ class QueuesadillaShellTest extends TestCase
      */
     public function testGetEngine()
     {
-        Log::config('stdout', ['engine' => 'File']);
-        Queue::config('default', [
+        Log::setConfig('stdout', ['engine' => 'File']);
+        Queue::setConfig('default', [
             'url' => 'mysql://username:password@localhost:80/database'
         ]);
         $logger = new NullLogger;


### PR DESCRIPTION
I have added a new engine (CakeEngine) to be able to use a cake datasource instead of the url. 

I have also increased phpunit version because unit tests were not running because of cake version and phpunit version. Additionally I fixed some deprecated notices but I am not sure if you were keeping them to be compatible with earlier 3.x versions..anyway let me know if you want to exclude anything.

Fixes #18 