### PR TITLE
Lock josegonzalez/queuesadilla

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "cakephp/cakephp": "~3.0",
         "php": ">=5.4",
-        "josegonzalez/queuesadilla": "0.0.*"
+        "josegonzalez/queuesadilla": "0.0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",


### PR DESCRIPTION
~That might be a little bit to much, but as of https://github.com/josegonzalez/php-queuesadilla/releases/tag/0.0.9, a new field was added which broke our deployment, as the migration wasn't updated in this repo.~

sorry