### PR TITLE
Queue::reset() should reset internal queue objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,16 +42,13 @@ before_script:
 
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
 
-  - sh -c "if [ '$PHPCS' = '1' ]; then composer require 'cakephp/cakephp-codesniffer:dev-master'; fi"
-
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
 
   - command -v phpenv > /dev/null && phpenv rehash || true
 
 script:
   - sh -c "if [ '$COVERALLS' = '1' ]; then vendor/bin/phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/satooshi/php-coveralls/bin/php-coveralls -v; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/php-coveralls/php-coveralls/bin/php-coveralls -v; fi"
   - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit --stderr; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=vendor,docs,tests/bootstrap.php,config/Migrations .; fi"
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",
-        "cakephp/cakephp-codesniffer": "dev-master",
-        "satooshi/php-coveralls": "dev-master"
+        "cakephp/cakephp-codesniffer": "^3.0",
+        "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -183,6 +183,7 @@ class Queue
         static::$_registry = null;
         static::$_config = [];
         static::$_dirtyConfig = true;
+        static::$_queuers = [];
     }
 
     /**

--- a/tests/TestCase/Queue/QueueTest.php
+++ b/tests/TestCase/Queue/QueueTest.php
@@ -108,4 +108,35 @@ class QueueTest extends TestCase
         Queue::setConfig('tests', ['url' => 'mysql://username:password@localhost:80/database']);
         Queue::setConfig('tests', ['url' => 'null://']);
     }
+
+    /**
+     * Ensure Queue resets correctly
+     *
+     * @return void
+     */
+    public function testReset()
+    {
+        // Set the initial config
+        Queue::setConfig('test', [
+            'url' => 'null://',
+        ]);
+
+        $registry = Queue::registry();
+        $engine = Queue::engine('test');
+        $queue = Queue::queue('test');
+
+        // Reset the queue
+        Queue::reset();
+
+        // Set the config after reset and assert that objects have been recreated
+        Queue::setConfig('test', [
+            'url' => 'null://',
+        ]);
+        $newRegistry = Queue::registry();
+        $newEngine = Queue::engine('test');
+        $newQueue = Queue::queue('test');
+        $this->assertNotSame($registry, $newRegistry, 'After reset the registry references the old object');
+        $this->assertNotSame($engine, $newEngine, 'After reset the engine references the old object');
+        $this->assertNotSame($queue, $newQueue, 'After reset the queue references the old object');
+    }
 }


### PR DESCRIPTION
Attempt at #25 

Note: on local install composer pulled cakephp 3.7 for me and a bunch of deprecated errors started popping up, so locally I've used `error_reporting(E_ALL & ~E_USER_DEPRECATED);` to run the tests.