### PR TITLE
Cake 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 services:
   - mysql
@@ -25,10 +23,10 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7.1
+    - php: 7.2
       env: PHPCS=1 DEFAULT=0
 
-    - php: 7.1
+    - php: 7.2
       env: COVERALLS=1 DEFAULT=0
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 [![Documentation Status](https://readthedocs.org/projects/cakephp-queuesadilla/badge/?version=latest&style=flat-square)](https://readthedocs.org/projects/cakephp-queuesadilla/?badge=latest)
 [![Gratipay](https://img.shields.io/gratipay/josegonzalez.svg?style=flat-square)](https://gratipay.com/~josegonzalez/)
 
-# CakePHP Queuesadilla Plugin 3.0
+# CakePHP Queuesadilla Plugin 4.0
 
 This plugin is a simple wrapper around the Queuesadilla queuing library, providing tighter integration with the CakePHP framework.
 
 ## Requirements
 
-* CakePHP 3.x
-* PHP 5.6+
+* CakePHP 4.x
+* PHP 7.2+
 * Patience
 
 ## Documentation

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,5 @@
         "psr-4": {
             "Josegonzalez\\CakeQueuesadilla\\Test\\": "tests"
         }
-    },
-    "prefer-stable": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
         }
     ],
     "require": {
-        "cakephp/cakephp": "^3.6",
-        "php": ">=5.4",
+        "cakephp/cakephp": "^4.0",
+        "php": ">=7.2",
         "josegonzalez/queuesadilla": "0.0.*",
         "ext-pcntl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.0",
-        "cakephp/cakephp-codesniffer": "^3.0",
+        "phpunit/phpunit": "~8.4.0",
+        "cakephp/cakephp-codesniffer": "dev-next",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {
@@ -34,5 +34,7 @@
         "psr-4": {
             "Josegonzalez\\CakeQueuesadilla\\Test\\": "tests"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~8.4.0",
-        "cakephp/cakephp-codesniffer": "dev-next",
+        "cakephp/cakephp-codesniffer": "~4.0.0",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,5 @@
             "Josegonzalez\\CakeQueuesadilla\\Test\\": "tests"
         }
     },
-    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="./tests/bootstrap.php"
     >
     <php>
@@ -18,11 +17,6 @@
     </testsuites>
 
     <filter>
-        <blacklist>
-            <directory suffix=".php">./docs</directory>
-            <directory suffix=".php">./vendor</directory>
-            <file>./tests/bootstrap.php</file>
-        </blacklist>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
         </whitelist>

--- a/src/Engine/CakeEngine.php
+++ b/src/Engine/CakeEngine.php
@@ -1,8 +1,9 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla\Engine;
 
 use Cake\Core\Exception\Exception;
-use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Hash;
 use josegonzalez\Queuesadilla\Engine\PdoEngine;
@@ -21,7 +22,7 @@ class CakeEngine extends PdoEngine
         'attempts' => 0,
         'attempts_delay' => 600,
         'table' => 'jobs',
-        'datasource' => 'default'
+        'datasource' => 'default',
     ];
 
     /**
@@ -31,7 +32,7 @@ class CakeEngine extends PdoEngine
     {
         $config = $this->settings;
         try {
-            /** @var Connection $connection */
+            /** @var \Cake\Database\Connection $connection */
             $connection = ConnectionManager::get(Hash::get($config, 'datasource'));
             $connection->connect();
             $this->connection = $connection->getDriver()->getConnection();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla;
 
 use Cake\Core\BasePlugin;

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla\Queue;
 
 use Cake\Core\ObjectRegistry;
 use Cake\Core\StaticConfigTrait;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
-use Josegonzalez\CakeQueuesadilla\Queue\QueueEngineRegistry;
+use josegonzalez\Queuesadilla\Engine\EngineInterface;
 use josegonzalez\Queuesadilla\Engine\NullEngine;
 use josegonzalez\Queuesadilla\Queue as Queuer;
-use RuntimeException;
 
 /**
  * Queue provides a consistent interface to Queuing in your application. It allows you
@@ -55,7 +56,6 @@ use RuntimeException;
  */
 class Queue
 {
-
     use StaticConfigTrait {
         parseDsn as protected _parseDsn;
     }
@@ -110,7 +110,7 @@ class Queue
      *
      * @return void
      */
-    protected static function _init()
+    protected static function _init(): void
     {
         if (empty(static::$_registry)) {
             static::$_registry = new QueueEngineRegistry();
@@ -127,7 +127,7 @@ class Queue
      *
      * @return void
      */
-    protected static function _loadConfig()
+    protected static function _loadConfig(): void
     {
         foreach (static::$_config as $name => $properties) {
             if (isset($properties['engine'])) {
@@ -149,7 +149,7 @@ class Queue
      * @return array The configuration array to be stored after parsing the DSN
      * @throws \InvalidArgumentException If not passed a string
      */
-    public static function parseDsn($dsn)
+    public static function parseDsn(string $dsn): array
     {
         $dsn = static::_parseDsn($dsn);
         if (is_array($dsn)) {
@@ -168,6 +168,7 @@ class Queue
 
         return $dsn;
     }
+
     /**
      * Reset all the connected loggers.  This is useful to do when changing the logging
      * configuration or during testing when you want to reset the internal state of the
@@ -178,7 +179,7 @@ class Queue
      *
      * @return void
      */
-    public static function reset()
+    public static function reset(): void
     {
         static::$_registry = null;
         static::$_config = [];
@@ -193,7 +194,7 @@ class Queue
      * @param \Cake\Core\ObjectRegistry|null $registry Injectable registry object.
      * @return \Cake\Core\ObjectRegistry
      */
-    public static function registry(ObjectRegistry $registry = null)
+    public static function registry(?ObjectRegistry $registry = null): ObjectRegistry
     {
         if ($registry) {
             static::$_registry = $registry;
@@ -213,7 +214,7 @@ class Queue
      * @return void
      * @throws \InvalidArgumentException When a queue engine cannot be created.
      */
-    protected static function _buildEngine($name)
+    protected static function _buildEngine(string $name): void
     {
         $registry = static::registry();
 
@@ -236,7 +237,7 @@ class Queue
      * @param string $config The configuration name you want an engine for.
      * @return \josegonzalez\Queuesadilla\Engine\EngineInterface When caching is disabled a null engine will be returned.
      */
-    public static function engine($config)
+    public static function engine(string $config): EngineInterface
     {
         if (!static::$_enabled) {
             return new NullEngine();
@@ -262,7 +263,7 @@ class Queue
      * @param string $config The configuration name you want an engine for.
      * @return \josegonzalez\Queuesadilla\Queue
      */
-    public static function queue($config)
+    public static function queue(string $config): Queuer
     {
         if (isset(static::$_queuers[$config])) {
             return static::$_queuers[$config];
@@ -281,7 +282,7 @@ class Queue
      * @param array  $options     an array of options for publishing the job
      * @return bool the result of the push
      */
-    public static function push($callable, $args = [], $options = [])
+    public static function push(callable $callable, array $args = [], array $options = []): bool
     {
         $config = Hash::get($options, 'config', 'default');
         $queue = static::queue($config);

--- a/src/Queue/QueueEngineRegistry.php
+++ b/src/Queue/QueueEngineRegistry.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla\Queue;
 
 use Cake\Core\App;
@@ -14,21 +16,16 @@ use RuntimeException;
  */
 class QueueEngineRegistry extends ObjectRegistry
 {
-
     /**
      * Resolve a queue engine classname.
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      *
      * @param string $class Partial classname to resolve.
-     * @return string|false Either the correct classname or false.
+     * @return string Either the correct classname or null.
      */
-    protected function _resolveClassName($class)
+    protected function _resolveClassName(string $class): ?string
     {
-        if (is_object($class)) {
-            return $class;
-        }
-
         return App::className($class, 'Queue/Engine', 'Engine');
     }
 
@@ -38,11 +35,11 @@ class QueueEngineRegistry extends ObjectRegistry
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      *
      * @param string $class The classname that is missing.
-     * @param string $plugin The plugin the queue engine is missing in.
+     * @param string|null $plugin The plugin the queue engine is missing in.
      * @return void
      * @throws \RuntimeException
      */
-    protected function _throwMissingClassError($class, $plugin)
+    protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new RuntimeException(sprintf('Could not load class %s', $class));
     }
@@ -58,7 +55,7 @@ class QueueEngineRegistry extends ObjectRegistry
      * @return \josegonzalez\Queuesadilla\Engine\EngineInterface The constructed queue engine class.
      * @throws \RuntimeException when an object doesn't implement the correct interface.
      */
-    protected function _create($class, $alias, $settings)
+    protected function _create($class, string $alias, array $settings): EngineInterface
     {
         if (is_callable($class)) {
             $class = $class($alias);
@@ -100,7 +97,7 @@ class QueueEngineRegistry extends ObjectRegistry
      * @param string $name The queue engine name.
      * @return void
      */
-    public function unload($name)
+    public function unload(string $name): void
     {
         unset($this->_loaded[$name]);
     }

--- a/src/Shell/QueuesadillaShell.php
+++ b/src/Shell/QueuesadillaShell.php
@@ -1,10 +1,16 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla\Shell;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Josegonzalez\CakeQueuesadilla\Queue\Queue;
+use josegonzalez\Queuesadilla\Engine\Base as BaseEngine;
+use josegonzalez\Queuesadilla\Worker\Base as BaseWorker;
+use Psr\Log\LoggerInterface;
 
 class QueuesadillaShell extends Shell
 {
@@ -14,7 +20,7 @@ class QueuesadillaShell extends Shell
      *
      * @return void
      */
-    public function main()
+    public function main(): void
     {
         $logger = Log::engine($this->params['logger']);
         $engine = $this->getEngine($logger);
@@ -28,7 +34,7 @@ class QueuesadillaShell extends Shell
      * @param \Psr\Log\LoggerInterface $logger logger
      * @return \josegonzalez\Queuesadilla\Engine\Base
      */
-    public function getEngine($logger)
+    public function getEngine(LoggerInterface $logger): BaseEngine
     {
         $config = Hash::get($this->params, 'config');
         $engine = Queue::engine($config);
@@ -47,7 +53,7 @@ class QueuesadillaShell extends Shell
      * @param \Psr\Log\LoggerInterface $logger logger
      * @return \josegonzalez\Queuesadilla\Worker\Base
      */
-    public function getWorker($engine, $logger)
+    public function getWorker(BaseEngine $engine, LoggerInterface $logger): BaseWorker
     {
         $worker = $this->params['worker'];
         $WorkerClass = "josegonzalez\\Queuesadilla\\Worker\\" . $worker . "Worker";
@@ -55,7 +61,7 @@ class QueuesadillaShell extends Shell
         return new $WorkerClass($engine, $logger, [
             'queue' => $engine->config('queue'),
             'maxRuntime' => $engine->config('maxRuntime'),
-            'maxIterations' => $engine->config('maxIterations')
+            'maxIterations' => $engine->config('maxIterations'),
         ]);
     }
 
@@ -64,7 +70,7 @@ class QueuesadillaShell extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
         $parser->addOption('config', [

--- a/src/Traits/QueueTrait.php
+++ b/src/Traits/QueueTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla\Traits;
 
 use Josegonzalez\CakeQueuesadilla\Queue\Queue;
@@ -13,7 +15,7 @@ trait QueueTrait
      * @param array  $options     an array of options for publishing the job
      * @return bool the result of the push
      */
-    protected function push($callable, $args = [], $options = [])
+    protected function push(callable $callable, array $args = [], array $options = []): bool
     {
         return Queue::push($callable, $args, $options);
     }

--- a/tests/TestCase/Engine/CakeEngineTest.php
+++ b/tests/TestCase/Engine/CakeEngineTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla\Test\Engine;
 
 use Cake\Datasource\ConnectionManager;
@@ -11,13 +13,12 @@ use Josegonzalez\CakeQueuesadilla\Queue\Queue;
  */
 class CakeEngineTest extends TestCase
 {
-
     /**
      * setup method
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Queue::reset();
@@ -31,7 +32,7 @@ class CakeEngineTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Queue::reset();
@@ -42,11 +43,11 @@ class CakeEngineTest extends TestCase
      *
      * @return void
      */
-    public function testValidConfig()
+    public function testValidConfig(): void
     {
         Queue::setConfig('valid', [
             'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
-            'datasource' => 'test'
+            'datasource' => 'test',
         ]);
         $engine = Queue::engine('valid');
         $this->assertInstanceOf('Josegonzalez\CakeQueuesadilla\Engine\CakeEngine', $engine);
@@ -58,14 +59,14 @@ class CakeEngineTest extends TestCase
      *
      * @return void
      */
-    public function testInvalidDatasourceName()
+    public function testInvalidDatasourceName(): void
     {
         $this->Logger->expects($this->once())
             ->method('error')
             ->with('The datasource configuration "wrong-datasource" was not found.');
         Queue::setConfig('invalid', [
             'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
-            'datasource' => 'wrong-datasource'
+            'datasource' => 'wrong-datasource',
         ]);
         $engine = Queue::engine('invalid');
         $engine->setLogger($this->Logger);
@@ -79,19 +80,19 @@ class CakeEngineTest extends TestCase
      *
      * @return void
      */
-    public function testInvalidConfig()
+    public function testInvalidConfig(): void
     {
         $this->Logger->expects($this->once())
             ->method('error')
             ->with('Datasource class wrong-datasource-class could not be found. ');
         Queue::setConfig('invalid', [
             'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
-            'datasource' => 'wrong-datasource-class'
+            'datasource' => 'wrong-datasource-class',
         ]);
         ConnectionManager::setConfig('wrong-datasource-class', [
             'user' => 'invalid-user',
             'password' => 'invalid-password',
-            'host' => 'localhost'
+            'host' => 'localhost',
         ]);
         $engine = Queue::engine('invalid');
         $engine->setLogger($this->Logger);
@@ -103,21 +104,21 @@ class CakeEngineTest extends TestCase
      *
      * @return void
      */
-    public function testInvalidConfigParams()
+    public function testInvalidConfigParams(): void
     {
         $this->Logger->expects($this->once())
             ->method('error')
             ->with($this->matchesRegularExpression('/Connection to database could not be established:/'));
         Queue::setConfig('invalid', [
             'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
-            'datasource' => 'wrong-datasource-params'
+            'datasource' => 'wrong-datasource-params',
         ]);
         ConnectionManager::setConfig('wrong-datasource-params', [
             'className' => 'Cake\Database\Connection',
             'driver' => 'Cake\Database\Driver\Mysql',
             'user' => 'invalid-user',
             'password' => 'invalid-password',
-            'host' => 'localhost'
+            'host' => 'localhost',
         ]);
         $engine = Queue::engine('invalid');
         $engine->setLogger($this->Logger);
@@ -129,7 +130,7 @@ class CakeEngineTest extends TestCase
      *
      * @return void
      */
-    public function testNoDatasource()
+    public function testNoDatasource(): void
     {
         Queue::setConfig('noDatasource', [
             'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
@@ -144,11 +145,11 @@ class CakeEngineTest extends TestCase
      *
      * @return void
      */
-    public function testConnection()
+    public function testConnection(): void
     {
         Queue::setConfig('valid', [
             'className' => 'Josegonzalez\CakeQueuesadilla\Engine\CakeEngine',
-            'datasource' => 'test'
+            'datasource' => 'test',
         ]);
         $engine = Queue::engine('valid');
         $this->assertInstanceOf('Josegonzalez\CakeQueuesadilla\Engine\CakeEngine', $engine);

--- a/tests/TestCase/Queue/QueueTest.php
+++ b/tests/TestCase/Queue/QueueTest.php
@@ -1,9 +1,8 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla\Test\Queue;
 
-use Cake\Core\Configure;
-use Cake\Core\Plugin;
-use Cake\Log\Engine\FileLog;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use Josegonzalez\CakeQueuesadilla\Queue\Queue;
@@ -14,13 +13,12 @@ use Josegonzalez\CakeQueuesadilla\Queue\Queue;
  */
 class QueueTest extends TestCase
 {
-
     /**
      * setup method
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Log::reset();
@@ -32,7 +30,7 @@ class QueueTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Log::reset();
@@ -42,11 +40,12 @@ class QueueTest extends TestCase
     /**
      * test all the errors from failed logger imports
      *
-     * @expectedException \InvalidArgumentException
      * @return void
      */
-    public function testImportingQueueEngineFailure()
+    public function testImportingQueueEngineFailure(): void
     {
+        $this->expectException('\InvalidArgumentException');
+
         Queue::setConfig('fail', []);
         Queue::engine('fail');
     }
@@ -56,11 +55,11 @@ class QueueTest extends TestCase
      *
      * @return void
      */
-    public function testValidKeyName()
+    public function testValidKeyName(): void
     {
         Log::setConfig('stdout', ['engine' => 'File']);
         Queue::setConfig('valid', [
-            'url' => 'mysql://username:password@localhost:80/database'
+            'url' => 'mysql://username:password@localhost:80/database',
         ]);
         $engine = Queue::engine('valid');
         $this->assertInstanceOf('josegonzalez\Queuesadilla\Engine\MysqlEngine', $engine);
@@ -69,11 +68,12 @@ class QueueTest extends TestCase
     /**
      * test that loggers have to implement the correct interface.
      *
-     * @expectedException \RuntimeException
      * @return void
      */
-    public function testNotImplementingInterface()
+    public function testNotImplementingInterface(): void
     {
+        $this->expectException('\RuntimeException');
+
         Queue::setConfig('fail', ['engine' => '\stdClass']);
         Queue::engine('fail');
     }
@@ -83,10 +83,10 @@ class QueueTest extends TestCase
      *
      * @return void
      */
-    public function testDrop()
+    public function testDrop(): void
     {
         Queue::setConfig('default', [
-            'url' => 'mysql://username:password@localhost:80/database'
+            'url' => 'mysql://username:password@localhost:80/database',
         ]);
         $result = Queue::configured();
         $this->assertContains('default', $result);
@@ -97,14 +97,16 @@ class QueueTest extends TestCase
         $result = Queue::configured();
         $this->assertNotContains('default', $result);
     }
+
     /**
      * Ensure you cannot reconfigure a log adapter.
      *
-     * @expectedException \BadMethodCallException
      * @return void
      */
-    public function testConfigErrorOnReconfigure()
+    public function testConfigErrorOnReconfigure(): void
     {
+        $this->expectException('\BadMethodCallException');
+
         Queue::setConfig('tests', ['url' => 'mysql://username:password@localhost:80/database']);
         Queue::setConfig('tests', ['url' => 'null://']);
     }
@@ -114,7 +116,7 @@ class QueueTest extends TestCase
      *
      * @return void
      */
-    public function testReset()
+    public function testReset(): void
     {
         // Set the initial config
         Queue::setConfig('test', [

--- a/tests/TestCase/Shell/QueuesadillaShellTest.php
+++ b/tests/TestCase/Shell/QueuesadillaShellTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\CakeQueuesadilla\Test\Shell;
 
 use Cake\Log\Log;
@@ -18,7 +20,7 @@ class QueuesadillaShellTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
@@ -33,7 +35,7 @@ class QueuesadillaShellTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Log::reset();
@@ -45,13 +47,13 @@ class QueuesadillaShellTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function testGetEngine()
+    public function testGetEngine(): void
     {
         Log::setConfig('stdout', ['engine' => 'File']);
         Queue::setConfig('default', [
-            'url' => 'mysql://username:password@localhost:80/database'
+            'url' => 'mysql://username:password@localhost:80/database',
         ]);
-        $logger = new NullLogger;
+        $logger = new NullLogger();
         $this->shell->params['config'] = 'default';
         $engine = $this->shell->getEngine($logger);
         $this->assertInstanceOf('josegonzalez\\Queuesadilla\\Engine\\MysqlEngine', $engine);
@@ -62,10 +64,10 @@ class QueuesadillaShellTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function testGetWorker()
+    public function testGetWorker(): void
     {
-        $logger = new NullLogger;
-        $engine = new NullEngine;
+        $logger = new NullLogger();
+        $engine = new NullEngine();
         $this->shell->params['worker'] = 'Sequential';
         $worker = $this->shell->getWorker($engine, $logger);
         $this->assertInstanceOf('josegonzalez\\Queuesadilla\\Worker\\SequentialWorker', $worker);
@@ -80,7 +82,7 @@ class QueuesadillaShellTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function testGetOptionParser()
+    public function testGetOptionParser(): void
     {
         $this->shell->loadTasks();
         $parser = $this->shell->getOptionParser();
@@ -95,7 +97,7 @@ class QueuesadillaShellTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function testMainSuccess()
+    public function testMainSuccess(): void
     {
         Queue::setConfig('default', [
             'url' => 'memory://',


### PR DESCRIPTION
Working towards a Cake 4 compatible version.
The codebase uses some stuff that is deprecated in Cake 4 but won't be removed until Cake 5.
I'm fine leaving it like it is. What do you think @josegonzalez ? 